### PR TITLE
Multi-Arch-Docker Image and Environment Var Support

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,69 @@
+name: Go
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  release:
+    types: [published]
+
+jobs:
+
+  build:
+    name: Build and push docker
+    runs-on: ubuntu-latest
+    steps:
+
+    - name: Set up Go 1.x
+      uses: actions/setup-go@v2
+      with:
+        go-version: ^1.13
+      id: go
+
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v2
+
+    - name: Test
+      run: go test -v .
+
+    - name: Build and push
+    # Build statically linked so we can use it in a from scratch dockerfile
+      env:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
+        BUILD_DOCKER: ${{ secrets.BUILD_DOCKER }}
+      run: |
+          if [ -z "$BUILD_DOCKER" ]; then echo "BUILD_DOCKER is not set, returning"; exit 0; fi;
+          echo ${{ secrets.DOCKER_PASSWORD }} | docker login -u ${{ secrets.DOCKER_USERNAME }} --password-stdin
+          CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -tags netgo -ldflags '-w' 
+          docker build -t $DOCKER_REPO:${{ github.sha }}-amd64 .
+          docker push $DOCKER_REPO:${{ github.sha }}-amd64
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm64 go build -a -tags netgo -ldflags '-w' 
+          docker build -t $DOCKER_REPO:${{ github.sha }}-arm64v8 .
+          docker push $DOCKER_REPO:${{ github.sha }}-arm64v8
+          CGO_ENABLED=0 GOOS=linux GOARCH=arm go build -a -tags netgo -ldflags '-w' 
+          docker build -t $DOCKER_REPO:${{ github.sha }}-arm32 .
+          docker push $DOCKER_REPO:${{ github.sha }}-arm32
+          export DOCKER_CLI_EXPERIMENTAL=enabled 
+          export REF=$(echo ${{ github.ref }} | sed 's#refs/.*/##')
+          docker manifest create ${DOCKER_REPO}:${{ github.sha }} ${DOCKER_REPO}:${{ github.sha }}-amd64 ${DOCKER_REPO}:${{ github.sha }}-arm64v8 ${DOCKER_REPO}:${{ github.sha }}-arm32
+          docker manifest annotate ${DOCKER_REPO}:${{ github.sha }} ${DOCKER_REPO}:${{ github.sha }}-arm32 --os linux --arch arm --variant v6
+          docker manifest annotate ${DOCKER_REPO}:${{ github.sha }} ${DOCKER_REPO}:${{ github.sha }}-arm32 --os linux --arch arm --variant v7
+          docker manifest annotate ${DOCKER_REPO}:${{ github.sha }} ${DOCKER_REPO}:${{ github.sha }}-arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push --purge ${DOCKER_REPO}:${{ github.sha }}
+          if [ "$REF" = "master" ]; then
+            DOCKER_TAG="latest"
+          else
+            if [ "$REF" = "" ]; then
+              return
+            fi
+              DOCKER_TAG=$REF
+          fi
+          docker manifest create ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${{ github.sha }}-amd64 ${DOCKER_REPO}:${{ github.sha }}-arm64v8 ${DOCKER_REPO}:${{ github.sha }}-arm32
+          docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${{ github.sha }}-arm32 --os linux --arch arm --variant v6
+          docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${{ github.sha }}-arm32 --os linux --arch arm --variant v7
+          docker manifest annotate ${DOCKER_REPO}:${DOCKER_TAG} ${DOCKER_REPO}:${{ github.sha }}-arm64v8 --os linux --arch arm64 --variant v8
+          docker manifest push --purge ${DOCKER_REPO}:${DOCKER_TAG}
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 tc4400_exporter
+.idea

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM scratch
+
+ADD tc4400_exporter /tc4400_exporter
+
+ENTRYPOINT ["/tc4400_exporter"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This is a Prometheus exporter for the Technicolor TC4400 DOCSIS 3.1 cable modem.
 It gathers metrics by scraping the modem's web interface.
 
-This was developed using a TC4400 running firmware SR70.12.33-180327, untested on other releases.
+This was developed using a TC4400 running firmware SR70.12.33-180327, and also tested against and 70.12.42-190604, untested on other releases.
 
 A scrape takes about 20 seconds so the scrape interval and timeout have to be configured accordingly:
 
@@ -18,4 +18,4 @@ A scrape takes about 20 seconds so the scrape interval and timeout have to be co
 
 Known issues:
 
-* The values of tc4400_network_receive_bytes_total and tc4400_network_transmit_bytes_total don't chanage.
+* The values of tc4400_network_receive_bytes_total and tc4400_network_transmit_bytes_total don't change.

--- a/tc4400_exporter.go
+++ b/tc4400_exporter.go
@@ -17,10 +17,10 @@ const (
 
 func main() {
 	var (
-		listenAddress   = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9623").String()
+		listenAddress   = kingpin.Flag("web.listen-address", "Address to listen on for web interface and telemetry.").Default(":9623").OverrideDefaultFromEnvar("TC4400_EXPORTER_PORT").String()
 		metricsPath     = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		clientScrapeURI = kingpin.Flag("client.scrape-uri", "Base URI on which to scrape TC4400.").Default("http://admin:bEn2o%23US9s@192.168.100.1/").String()
-		clientTimeout   = kingpin.Flag("client.timeout", "Timeout for HTTP requests to TC440.").Default("50s").Duration()
+		clientScrapeURI = kingpin.Flag("client.scrape-uri", "Base URI on which to scrape TC4400.").Default("http://admin:bEn2o%23US9s@192.168.100.1/").OverrideDefaultFromEnvar("TC4400_EXPORTER_SCRAPEURI").String()
+		clientTimeout   = kingpin.Flag("client.timeout", "Timeout for HTTP requests to TC440.").Default("50s").OverrideDefaultFromEnvar("TC4400_EXPORTER_CLIENTTIMEOUT").Duration()
 	)
 
 	log.AddFlags(kingpin.CommandLine)


### PR DESCRIPTION
Hi Markus,

I've added github actions pipeline to create docker images for regular x86, arm and arm64 with proper multi-arch manifests. I'm using those images in my little home k8s cluster, where my prometheus instance runs too. Not sure if it's worth building a helm template .. but I think it's always worth building multi-arch images :) they can easily be extended to support any arch we can compile the binary for as the Dockerfile is so simple, it doesn't require emulation to execute.

If you want to publish docker images, pls configure the following secrets in your repo:
```
        username: ${{ secrets.DOCKER_USERNAME }}
        password: ${{ secrets.DOCKER_PASSWORD }}
        DOCKER_REPO: ${{ secrets.DOCKER_REPO }}
        BUILD_DOCKER: ${{ secrets.BUILD_DOCKER }}
```

I've also extended the code a bit to support environment variables instead of arguments because that's the standard way to configure k8s deployments.

Thanks for your code, I wouldn't have gone through all the trouble writing it, but I'm really glad you did and it's been a lot of fun getting to know github actions a bit. Well .. I'm still favouring gitlab, travis and jenkins .. but it's ok for a simple pipeline I guess. I've tried out a couple of different ways building the images in gitlab actions ... in the end, I opted for a simple bash script that does it all.

BTW: I've tried using github packages, but there's a "missing feature" in github docker packages ... they can't be pulled anonymously, which is a bit fucked up as that's a basic required feature I'd say, also the docker manifests won't function, not sure why .. maybe not supported by github packages.

best regards!
Mark